### PR TITLE
Add /linkyoutubemusic OAuth linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ Telegram bot that monitors channels for music links and adds tracks to a Spotify
 Currently supports:
 - Spotify links (`open.spotify.com/...` and `spotify.link/...`)
 - YouTube / YouTube Music links (resolves title/artist from the page, searches Spotify, and adds the best match)
+
+Commands:
+- `/link` (DM only): link your Spotify account.
+- `/unlink` (DM only): unlink your Spotify account.
+- `/linkyoutubemusic` (DM only): link your YouTube account (Google OAuth).

--- a/src/youtube-token-manager.js
+++ b/src/youtube-token-manager.js
@@ -1,0 +1,54 @@
+/**
+ * YouTube (Google) OAuth Token Manager using Cloudflare KV Storage.
+ *
+ * NOTE: This reuses the existing SPOTIFY_TOKENS KV binding for storage.
+ * If we ever rename the binding, update this class accordingly.
+ */
+
+export class YouTubeTokenManager {
+  constructor(env) {
+    this.env = env;
+    this.kv = env.SPOTIFY_TOKENS;
+  }
+
+  userTokenKey(telegramUserId) {
+    return `youtube_user_oauth:${telegramUserId}`;
+  }
+
+  stateKey(state) {
+    return `youtube_oauth_state:${state}`;
+  }
+
+  async setTelegramUserTokens(telegramUserId, tokenResponse) {
+    const expiresAt = Date.now() + tokenResponse.expires_in * 1000;
+    const tokenData = {
+      access_token: tokenResponse.access_token,
+      refresh_token: tokenResponse.refresh_token,
+      expires_at: expiresAt,
+      updated_at: new Date().toISOString(),
+    };
+
+    await this.kv.put(
+      this.userTokenKey(telegramUserId),
+      JSON.stringify(tokenData),
+    );
+  }
+
+  async unlinkTelegramUser(telegramUserId) {
+    await this.kv.delete(this.userTokenKey(telegramUserId));
+  }
+
+  async storeOAuthState(state, payload) {
+    // expire after 10 minutes
+    await this.kv.put(this.stateKey(state), JSON.stringify(payload), {
+      expirationTtl: 10 * 60,
+    });
+  }
+
+  async consumeOAuthState(state) {
+    const key = this.stateKey(state);
+    const payload = await this.kv.get(key, "json");
+    if (payload) await this.kv.delete(key);
+    return payload;
+  }
+}

--- a/src/youtube-user-auth.js
+++ b/src/youtube-user-auth.js
@@ -1,0 +1,66 @@
+/**
+ * Google / YouTube OAuth helpers.
+ *
+ * We use YouTube Data API scopes so we can later add tracks (videos) to a
+ * playlist on behalf of the user.
+ */
+
+export const YOUTUBE_SCOPES = ["https://www.googleapis.com/auth/youtube"];
+
+export async function createStateToken() {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function youtubeAuthorizeUrl({
+  clientId,
+  redirectUri,
+  state,
+  scopes,
+}) {
+  const u = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  u.searchParams.set("client_id", clientId);
+  u.searchParams.set("redirect_uri", redirectUri);
+  u.searchParams.set("response_type", "code");
+  u.searchParams.set("scope", scopes.join(" "));
+
+  // Critical: request refresh token.
+  u.searchParams.set("access_type", "offline");
+  u.searchParams.set("prompt", "consent");
+
+  u.searchParams.set("state", state);
+  return u.toString();
+}
+
+export async function exchangeCodeForTokens({ env, code, redirectUri }) {
+  const clientId = env.GOOGLE_CLIENT_ID;
+  const clientSecret = env.GOOGLE_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    throw new Error("Missing GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET");
+  }
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      grant_type: "authorization_code",
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Google token exchange failed: ${res.status} ${text}`);
+  }
+
+  return await res.json();
+}


### PR DESCRIPTION
Adds a DM-only /linkyoutubemusic command and Google OAuth flow endpoints (/youtube/link, /youtube/callback). Stores per-user tokens in KV for future YouTube playlist support.\n\nRequired env vars:\n- GOOGLE_CLIENT_ID\n- GOOGLE_CLIENT_SECRET\n- PUBLIC_BASE_URL (for redirect URL)\n\nNotes:\n- Uses scope https://www.googleapis.com/auth/youtube (offline refresh).\n- Tokens stored under KV keys youtube_user_oauth:<tg_user_id>.